### PR TITLE
パスワード編集画面実装

### DIFF
--- a/app/assets/javascripts/passwords.coffee
+++ b/app/assets/javascripts/passwords.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/passwords.scss
+++ b/app/assets/stylesheets/passwords.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the passwords controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,41 @@
+class PasswordsController < ApplicationController
+
+  def show
+    @user = current_user
+    redirect_to @user
+  end
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    current_password = params[:user][:current_password]
+    if current_password.present?
+      if @user.authenticate(current_password)
+        @user.assign_attributes(user_params)
+        if @user.save
+          flash[:success] = 'パスワードを変更しました。'
+          redirect_to @user
+        else
+          render 'edit'
+        end
+      else
+        @user.errors.add(:current_password)
+        render 'edit'
+      end
+    else
+      @user.errors.add(:current_password, :blank)
+      render 'edit'
+    end
+  end
+
+  private def user_params
+    params.require(:user).permit(
+      :current_password,
+      :password,
+      :password_confirmation
+    )
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,14 +48,17 @@ class UsersController < ApplicationController
   end
 
   private def user_params
-    params.require(:user).permit(:new_profile_picture, :remove_profile_picture,
-                                 :name, :email, :sex, :birthday,
-                                 :password, :password_confirmation)
+    attrs = [
+      :new_profile_picture, :remove_profile_picture,
+      :name, :email, :sex, :birthday
+    ]
+
+    attrs << :password << :password_confirmation if params[:action] == 'create'
+    params.require(:user).permit(attrs)
   end
 
   private def correct_user
     @user = User.find(params[:id])
     redirect_to(root_url) unless current_user?(@user)
   end
-
 end

--- a/app/helpers/passwords_helper.rb
+++ b/app/helpers/passwords_helper.rb
@@ -1,0 +1,2 @@
+module PasswordsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   attr_accessor :remember_token
+  attr_accessor :current_password
 
   has_one_attached :profile_picture
   attribute :new_profile_picture
@@ -19,12 +20,15 @@ class User < ApplicationRecord
   end
 
   validates :name, presence: true, length: { maximum: 50 }
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
   validates :email, presence: true, uniqueness: true, length: { maximum: 255 },
                     format: { with: VALID_EMAIL_REGEX }
 
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  VALID_PASSWORD_REGEX = /\A\w*\z/.freeze
+  validates :password, presence: { if: :current_password },
+                       length: { minimum: 6, allow_nil: true },
+                       format: { with: VALID_PASSWORD_REGEX }
 
   validate if: :new_profile_picture do
     if new_profile_picture.respond_to?(:content_type)

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,0 +1,30 @@
+<% title_tag_set("パスワードの変更")%>
+
+<%= link_to 'マイアカウントに戻る', @user %>
+
+<h1>パスワードの変更</h1>
+
+<%= form_with model: @user, url: password_path, local: true do |form| %>
+<%= render 'shared/error_messages',object: form.object %>
+
+
+<div class='form'>
+
+  <div class="form-group">
+    <%= form.label :current_password %>
+    <%= form.password_field :current_password, class: 'form-control'  %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :password %>
+    <%= form.password_field :password, class: 'form-control'  %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :password_confirmation %>
+    <%= form.password_field :password_confirmation, class: 'form-control' %>
+  </div>
+
+  <%= form.submit class:'btn btn-primary'%>
+</div>
+<% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -23,6 +23,7 @@
     <%= form.text_field :email, class: 'form-control' %>
   </div>
 
+  <% if @user.new_record? %>
   <div class="form-group">
     <%= form.label :password %>
     <%= form.password_field :password, class: 'form-control'  %>
@@ -32,6 +33,7 @@
     <%= form.label :password_confirmation %>
     <%= form.password_field :password_confirmation, class: 'form-control' %>
   </div>
+  <% end %>
 
   <div class="form-group">
     <%= form.label '性別' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,5 @@
 <% title_tag_set("マイアカウントの編集")%>
 
 <h1>マイアカウントの編集</h1>
+<%= link_to 'マイアカウントに戻る', current_user %>
 <%= render 'form' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,10 @@
 <h1><%= @user.name %>さんのページ</h1>
 <div class ='row'>
 <div class="user col-md-4">
+  <% if current_user?(@user) %>
+    <%= link_to 'マイアカウントの編集', edit_user_path(@user) %>
+    <%= link_to 'パスワードの変更', edit_password_path(@user) %>
+  <% end %>
 <table>
 <tr>
   <th>プロフィール画像</th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'passwords/edit'
   root 'static_pages#top'
   get '/top', to: 'static_pages#top'
   get '/about', to: 'static_pages#about'
@@ -9,8 +10,9 @@ Rails.application.routes.draw do
 
   resources :users
   resources :posts
-  resources :likes, only: %w[create destroy]
+  resources :likes, only: [:create, :destroy]
 
+  resource :password, only: [:show, :edit, :update]
   namespace :admin do
     root 'static_pages#top'
     resources :users, only: %I[index show destroy]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -81,7 +81,32 @@ RSpec.describe User, type: :model do
       expect(user.valid?).to eq(true)
     end
 
-    it '性別のデフォルト値は0で保存される' do
+    it 'パスワードは空白の場合は無効' do
+      user = build :testuser, password: '', password_confirmation: ''
+      expect(user).to_not be_valid
+    end
+
+    it '有効なパスワード' do
+      user = build :testuser
+      valid_passwords = %w[abcdef ABCDEF 123456 ______ 1aA_2bB_]
+      valid_passwords.each do |valid_password|
+        user.password = valid_password
+        user.password_confirmation = valid_password
+        expect(user.valid?).to eq(true)
+      end
+    end
+
+    it '無効なパスワード' do
+      user = build :testuser
+      invalid_passwords = %w[a-cdef A.CDEF 1@3456 _\ ____ 1$A_2bB_]
+      invalid_passwords.each do |invalid_password|
+        user.password = invalid_password
+        user.password_confirmation = invalid_password
+        expect(user.valid?).to eq(false)
+      end
+    end
+
+    it '性別のデフォルト値は0' do
       user = User.new
       expect(user.sex).to eq 0
     end

--- a/spec/system/passwords_spec.rb
+++ b/spec/system/passwords_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe "Passwords", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  describe 'パスワード変更機能' do
+    let(:user) { create :testuser }
+    let(:current_password) { user.password }
+    let(:valid_password) { 'password2' }
+    let(:invalid_password) { '      ' }
+
+    before do
+      valid_login(user)
+    end
+
+    it '有効な情報を入力してパスワードを変更する' do
+      visit edit_password_path(user)
+
+      fill_in 'user_current_password', with: current_password
+      fill_in 'user_password', with: valid_password
+      fill_in 'user_password_confirmation', with: valid_password
+
+      click_on 'Update User'
+
+      expect(user.reload.authenticate(valid_password)).to eq user
+      expect(user.reload.authenticate(current_password)).to eq false
+
+      expect(current_path).to eq user_path(user)
+      expect(page).to have_content "#{user.name}さんのページ"
+      expect(page).to have_css('div.alert.alert-success')
+    end
+    it '無効な情報を入力してエラーメッセージを表示させる' do
+      visit edit_password_path(user)
+
+      fill_in 'user_current_password', with: current_password
+      fill_in 'user_password', with: invalid_password
+      fill_in 'user_password_confirmation', with: invalid_password
+
+      click_on 'Update User'
+
+      expect(user.reload.authenticate(invalid_password)).to eq false
+      expect(user.reload.authenticate(current_password)).to eq user
+
+      expect(page).to have_field 'user_current_password'
+      expect(page).to have_field 'user_password'
+      expect(page).to have_field 'user_password_confirmation'
+      expect(page).to have_css('div.alert.alert-danger')
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -190,8 +190,6 @@ RSpec.describe 'Users', type: :system do
 
         fill_in 'user_name', with: 'lily'
         fill_in 'user_email', with: 'lily@exam.jp'
-        fill_in 'user_password', with: 'password'
-        fill_in 'user_password_confirmation', with: 'password'
         select '女', from: 'user_sex'
         select '2004', from: 'user_birthday_1i'
         select '12', from: 'user_birthday_2i'
@@ -247,8 +245,6 @@ RSpec.describe 'Users', type: :system do
           expect(page).to have_css "img[src$='profile1.png']"
 
           attach_file 'user_new_profile_picture', "#{Rails.root}/spec/factories/profile2.png"
-          fill_in 'user_password', with: 'password'
-          fill_in 'user_password_confirmation', with: 'password'
 
           click_on 'Update User'
 
@@ -262,8 +258,6 @@ RSpec.describe 'Users', type: :system do
           visit edit_user_path(user)
 
           check('user_remove_profile_picture')
-          fill_in 'user_password', with: 'password'
-          fill_in 'user_password_confirmation', with: 'password'
 
           click_on 'Update User'
 
@@ -278,8 +272,6 @@ RSpec.describe 'Users', type: :system do
           visit edit_user_path(user)
 
           attach_file 'user_new_profile_picture', "#{Rails.root}/spec/factories/profile1.png"
-          fill_in 'user_password', with: 'password'
-          fill_in 'user_password_confirmation', with: 'password'
 
           click_on 'Update User'
 


### PR DESCRIPTION
・ユーザー情報編集機能の内、パスワード部分を別ページに変更。
passwords_controller作成

・パスワードのバリデーション変更
現在のパスワードが入力されているときだけ、presenceを有効に、
lengthにallow_nilを追加
formatで半角英数字かアンダースコアのみが0回以上を指定

・パスワード関連のテスト追加、修正